### PR TITLE
[#2] 가입 후 이메일 인증 Service Layer 구현

### DIFF
--- a/src/main/java/dev/flab/studytogether/domain/member/exception/LinkExpiredException.java
+++ b/src/main/java/dev/flab/studytogether/domain/member/exception/LinkExpiredException.java
@@ -1,0 +1,9 @@
+package dev.flab.studytogether.domain.member.exception;
+
+import dev.flab.studytogether.exception.BadRequestException;
+
+public class LinkExpiredException extends BadRequestException {
+    public LinkExpiredException() {
+        super("링크가 만료되었습니다.");
+    }
+}

--- a/src/main/java/dev/flab/studytogether/domain/member/exception/LinkNotValidException.java
+++ b/src/main/java/dev/flab/studytogether/domain/member/exception/LinkNotValidException.java
@@ -1,0 +1,9 @@
+package dev.flab.studytogether.domain.member.exception;
+
+import dev.flab.studytogether.exception.BadRequestException;
+
+public class LinkNotValidException extends BadRequestException {
+    public LinkNotValidException() {
+        super("유효하지 않은 링크입니다.");
+    }
+}

--- a/src/main/java/dev/flab/studytogether/domain/member/repository/EmailAuthenticationRepository.java
+++ b/src/main/java/dev/flab/studytogether/domain/member/repository/EmailAuthenticationRepository.java
@@ -1,0 +1,12 @@
+package dev.flab.studytogether.domain.member.repository;
+
+import dev.flab.studytogether.domain.member.entity.EmailAuthentication;
+import org.springframework.stereotype.Repository;
+import java.util.Optional;
+
+@Repository
+public interface EmailAuthenticationRepository {
+    EmailAuthentication save(EmailAuthentication emailConfirm);
+    Optional<EmailAuthentication> findByEmailAndAuthKey(String email, String authKey);
+    EmailAuthentication update(EmailAuthentication emailConfirm);
+}

--- a/src/main/java/dev/flab/studytogether/domain/member/repository/EmailAuthenticationRepositoryImpl.java
+++ b/src/main/java/dev/flab/studytogether/domain/member/repository/EmailAuthenticationRepositoryImpl.java
@@ -1,0 +1,23 @@
+package dev.flab.studytogether.domain.member.repository;
+
+import dev.flab.studytogether.domain.member.entity.EmailAuthentication;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+@Repository
+public class EmailAuthenticationRepositoryImpl implements EmailAuthenticationRepository{
+    @Override
+    public EmailAuthentication save(EmailAuthentication emailConfirm) {
+        return null;
+    }
+
+    @Override
+    public Optional<EmailAuthentication> findByEmailAndAuthKey(String email, String authKey) {
+        return Optional.empty();
+    }
+
+    @Override
+    public EmailAuthentication update(EmailAuthentication emailConfirm) {
+        return null;
+    }
+}

--- a/src/main/java/dev/flab/studytogether/domain/member/service/MemberV2Service.java
+++ b/src/main/java/dev/flab/studytogether/domain/member/service/MemberV2Service.java
@@ -1,0 +1,81 @@
+package dev.flab.studytogether.domain.member.service;
+
+import dev.flab.studytogether.domain.member.entity.EmailAuthentication;
+import dev.flab.studytogether.domain.member.entity.MemberV2;
+import dev.flab.studytogether.domain.member.exception.MemberEmailAddressExistsException;
+import dev.flab.studytogether.domain.member.exception.MemberNicknameExistsException;
+import dev.flab.studytogether.domain.member.repository.EmailAuthenticationRepository;
+import dev.flab.studytogether.domain.member.repository.MemberV2Repository;
+import dev.flab.studytogether.utils.RandomUtil;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class MemberV2Service {
+    private final MemberV2Repository memberV2Repository;
+    private final EmailAuthenticationRepository emailAuthenticationRepository;
+    private final NotificationService notificationService;
+    private final PasswordEncoder passwordEncoder;
+
+    public MemberV2Service(MemberV2Repository memberV2Repository,
+                           EmailAuthenticationRepository emailAuthenticationRepository,
+                           NotificationService notificationService,
+                           PasswordEncoder passwordEncoder) {
+        this.memberV2Repository = memberV2Repository;
+        this.emailAuthenticationRepository = emailAuthenticationRepository;
+        this.notificationService = notificationService;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Transactional
+    public MemberV2 signUp(String email, String password, String nickname) {
+        if(memberV2Repository.isEmailExists(email)) {
+            throw new MemberEmailAddressExistsException();
+        }
+
+        if(memberV2Repository.isNicknameExists(nickname)) {
+            throw new MemberNicknameExistsException();
+        }
+
+        MemberV2 newMember = MemberV2.createNewMember(
+                email,
+                passwordEncoder.encode(password),
+                nickname);
+
+        String authKey = RandomUtil.generateRandomToken(16);
+
+        EmailAuthentication emailConfirm = new EmailAuthentication(email, authKey);
+
+        memberV2Repository.save(newMember);
+        emailAuthenticationRepository.save(emailConfirm);
+        notificationService.sendEmailAddressVerification(email, authKey);
+
+        return newMember;
+    }
+
+    @Transactional
+    public void emailAddressAuthenticate(String email, String authKey) {
+        MemberV2 member = memberV2Repository.findByEmail(email)
+                .orElseThrow(LinkNotValidException::new);
+
+        // 이미 인증 완료된 사용자
+        if(member.isEmailAuthenticated()) {
+            throw new LinkNotValidException();
+        }
+
+        EmailAuthentication emailConfirm = emailAuthenticationRepository.findByEmailAndAuthKey(email, authKey)
+                .orElseThrow(LinkNotValidException::new);
+
+        // 링크 유효기간이 만료됐을 경우
+        if(emailConfirm.isExpired()) {
+            throw new LinkExpiredException();
+        }
+
+        member.changeToEmailAuthenticated();
+
+        memberV2Repository.update(member);
+        emailAuthenticationRepository.update(emailConfirm);
+    }
+
+}


### PR DESCRIPTION
## 이메일 인증
### 관련 이슈
- #2 

### 인증 플로우
**1. 회원 정보 조회**
- 주어진 이메일 주소로 회원 정보를 조회.
- 해당 이메일을 가진 회원이 없으면 LinkNotValidException 예외를 발생.

**2. 이미 인증된 사용자 확인**
- 이미 인증된 경우에는 LinkNotValidException 예외를 발생.

**3. 이메일 인증 정보 조회**
- 이메일과 인증 키를 사용하여 이메일 인증 정보를 조회.
- 인증 정보가 없으면 LinkNotValidException 예외를 발생.

**4. 링크 유효 기간 확인**
- 만료되었다면 LinkExpiredException 예외를 발생.

**5. 이메일 인증 상태 변경**
- 회원의 이메일 인증 상태를 변경.

### `EMAIL_AUTHENTICATION` 테이블 DDL
```
CREATE TABLE `EMAIL_AUTHENTICATION` (
  `id` bigint NOT NULL AUTO_INCREMENT,
  `email` varchar(255) NOT NULL,
  `auth_key` varchar(255) NOT NULL,
  `created_at` datetime NOT NULL,
  `expired_date_time` datetime NOT NULL,
  PRIMARY KEY (`id`),
  KEY `idx_EMAIL_VERIFICATION_email_auth_key` (`email`,`auth_key`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
```