### PR TITLE
[#13] 채팅 기능 구현을 위한 Entity 설계

### DIFF
--- a/src/main/java/dev/flab/studytogether/domain/chat/entity/Chat.java
+++ b/src/main/java/dev/flab/studytogether/domain/chat/entity/Chat.java
@@ -1,0 +1,24 @@
+package dev.flab.studytogether.domain.chat.entity;
+
+import lombok.Getter;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn
+@Getter
+public abstract class Chat {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private LocalDateTime createdAt;
+
+    protected Chat() {}
+
+    public Chat(Long id, LocalDateTime createdAt) {
+        this.id = id;
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/dev/flab/studytogether/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/dev/flab/studytogether/domain/chat/entity/ChatMessage.java
@@ -1,0 +1,28 @@
+package dev.flab.studytogether.domain.chat.entity;
+
+import lombok.Getter;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+public class ChatMessage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private Long chatId;
+    private Long memberId;
+    private String content;
+    private LocalDateTime messageSentTime;
+
+    protected ChatMessage() {}
+
+    public ChatMessage(Long id, Long chatId, Long memberId, String content, LocalDateTime messageSentTime) {
+        this.id = id;
+        this.chatId = chatId;
+        this.memberId = memberId;
+        this.content = content;
+        this.messageSentTime = messageSentTime;
+    }
+}

--- a/src/main/java/dev/flab/studytogether/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/dev/flab/studytogether/domain/chat/entity/ChatMessage.java
@@ -13,15 +13,17 @@ public class ChatMessage {
     private Long id;
     private Long chatId;
     private Long memberId;
+    private String memberNickName;
     private String content;
     private LocalDateTime messageSentTime;
 
     protected ChatMessage() {}
 
-    public ChatMessage(Long id, Long chatId, Long memberId, String content, LocalDateTime messageSentTime) {
+    public ChatMessage(Long id, Long chatId, Long memberId, String memberNickName, String content, LocalDateTime messageSentTime) {
         this.id = id;
         this.chatId = chatId;
         this.memberId = memberId;
+        this.memberNickName = memberNickName;
         this.content = content;
         this.messageSentTime = messageSentTime;
     }

--- a/src/main/java/dev/flab/studytogether/domain/chat/entity/StudyGroupChat.java
+++ b/src/main/java/dev/flab/studytogether/domain/chat/entity/StudyGroupChat.java
@@ -2,11 +2,13 @@ package dev.flab.studytogether.domain.chat.entity;
 
 import lombok.Getter;
 
+import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@DiscriminatorValue("STUDY_GROUP_CHAT")
 public class StudyGroupChat extends Chat {
     private Long studyGroupId;
 

--- a/src/main/java/dev/flab/studytogether/domain/chat/entity/StudyGroupChat.java
+++ b/src/main/java/dev/flab/studytogether/domain/chat/entity/StudyGroupChat.java
@@ -1,0 +1,19 @@
+package dev.flab.studytogether.domain.chat.entity;
+
+import lombok.Getter;
+
+import javax.persistence.Entity;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+public class StudyGroupChat extends Chat {
+    private Long studyGroupId;
+
+    protected StudyGroupChat() {}
+
+    public StudyGroupChat(Long id, LocalDateTime createdAt, Long studyGroupId) {
+        super(id, createdAt);
+        this.studyGroupId = studyGroupId;
+    }
+}


### PR DESCRIPTION
- [x] 관련 이슈 : https://github.com/wooni97/study-together-develop/issues/22

## Chat 엔티티
###  채팅 기능의 확장을 고려한 설계
- 스터디 그룹당 하나의 채팅 기능만 고려했지만, 이후 다양한 채팅 유형(예: 그룹 내 프라이빗 채팅, 1:1 다이렉트 메시지)으로 확장될 가능성을 배제할 수 없음.
- 스터디 그룹과 채팅 간의 의존성을 최소화하는 설계가 필요.

### 추상화 및 상속 구조
<img src="https://github.com/user-attachments/assets/160188fd-211a-4f68-aa45-ee7101954e3c" width="400" height="200" alt="Image">

- `Chat` 추상 클래스 정의 
- 하위 클래스에서 필요한 의존성 및 필드 추가

### 필드
- `Long id` : 식별자
- `LocalDateTime createdAt` : 채팅방 생성 시간

---

## ChatMessage 엔티티
### 필드
- `Long id` : 식별자
- `Long chatId` : (FK) Chat 엔티티 식별자
- `Long memberId` : (FK) 메시지를 보낸 멤버 식별자
- `String content` : 메시지 내용
- `LocalDateTime messageSentTime` : 메시지 보낸 시간

### Chat 엔티티와 연관관계 매핑이 아닌 식별자만 필드로 선언한 이유
**1. Chat -> ChatMessage 일대다 단방향은 JPA에서 성능 비효율을 발생**
- ex.) ChatMessage 삽입시 insert 후 다시 update하는 쿼리 비효율 문제

**2. Chat 엔티티에서 List 형태로 ChatMessage를 필드로 관리하지 않는 이유**
- ChatMessage 데이터가 많아질 시 조회 성능 문제 발생 가능성

**3. Chat 엔티티가 ChatMessage를 알아야 할 필요가 없음**
- Chat 엔티티는 단순히 채팅방 정보를 나타내는 역할
- 개별 메시지의 CRUD는 ChatMessage를 통해 처리